### PR TITLE
Add another deep link to the repository at gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DAViCal CalDAV Server by Andrew McMillan
 Please Note
 ===
 
-The official DAViCal repository is now on
+The [official DAViCal repository](https://gitlab.com/davical-project/davical) is now on
 [GitLab](https://gitlab.com). Please use that repository as this
 GitHub repository will gradually stagnate. Please post issues and pull
 requests there as well. The repository is at:


### PR DESCRIPTION
I was tricked by clicking on the link pointing to glitab's main-page twice.

@julien2512 I'm passing this patch to you since I want to get rid of my clone and you are the on who worked on davical most recently.